### PR TITLE
dataset not empty check before normalization @inference.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Options:
   -i, --inpath TEXT     The input fast5 directory path
   -o, --outpath TEXT    The output pytorch tensor directory path
   -b, --batch INTEGER   Batch size, default 10000
+  -b, --trpartition FLOAT   Train partition size, default None
   -c, --cutoff INTEGER  Cutoff the first c signals
   --help                Show this message and exit.
 ```

--- a/inference.py
+++ b/inference.py
@@ -98,21 +98,23 @@ def main(model, infile, outfile, batch, cutoff):
 	it = 0
 	for fileNM in glob.glob(infile + '/*.fast5'):
 		data_test, data_name = get_raw_data(infile, fileNM, data_test, data_name, cutoff)
-		it += 1
 
-		if len(data_test)>0 and it == batch:
-			print("[Step 1]$$$$$$$$$$ Done loading data with batch " + str(batchi)+ \
-				", Getting " + str(len(data_test)) + " of sequences")
-			data_test = normalization(data_test, batchi)
-			process(data_test, data_name, batchi, bmodel, outfile, device)
-			print("[Step 4]$$$$$$$$$$ Done with batch " + str(batchi))
-			print()
-			del data_test
-			data_test = []
-			del data_name
-			data_name = []
-			batchi += 1
-			it = 0
+		if len(data_test) > 0:
+			it += 1
+
+			if it == batch:
+				print("[Step 1]$$$$$$$$$$ Done loading data with batch " + str(batchi)+ \
+					", Getting " + str(len(data_test)) + " of sequences")
+				data_test = normalization(data_test, batchi)
+				process(data_test, data_name, batchi, bmodel, outfile, device)
+				print("[Step 4]$$$$$$$$$$ Done with batch " + str(batchi))
+				print()
+				del data_test
+				data_test = []
+				del data_name
+				data_name = []
+				batchi += 1
+				it = 0
 
 	print("[Step FINAL]--- %s seconds ---" % (time.time() - start_time))
 

--- a/inference.py
+++ b/inference.py
@@ -100,7 +100,7 @@ def main(model, infile, outfile, batch, cutoff):
 		data_test, data_name = get_raw_data(infile, fileNM, data_test, data_name, cutoff)
 		it += 1
 
-		if it == batch:
+		if len(data_test)>0 and it == batch:
 			print("[Step 1]$$$$$$$$$$ Done loading data with batch " + str(batchi)+ \
 				", Getting " + str(len(data_test)) + " of sequences")
 			data_test = normalization(data_test, batchi)

--- a/preprocess.py
+++ b/preprocess.py
@@ -1,5 +1,6 @@
 from ont_fast5_api.fast5_interface import get_fast5_file
 import os
+import math
 import glob
 import click
 import torch
@@ -8,85 +9,183 @@ from scipy import stats
 
 
 def normalization(data_test, xi, outpath, pos = True):
-	mad = stats.median_abs_deviation(data_test, axis=1, scale='normal')
-	m = np.median(data_test, axis=1)   
-	data_test = ((data_test - np.expand_dims(m,axis=1))*1.0) / (1.4826 * np.expand_dims(mad,axis=1))
+		mad = stats.median_abs_deviation(data_test, axis=1, scale='normal')
+		m = np.median(data_test, axis=1)
+		data_test = ((data_test - np.expand_dims(m,axis=1))*1.0) / (1.4826 * np.expand_dims(mad,axis=1))
 
-	x = np.where(np.abs(data_test) > 3.5)
-	for i in range(x[0].shape[0]):
-		if x[1][i] == 0:
-			data_test[x[0][i],x[1][i]] = data_test[x[0][i],x[1][i]+1]
-		elif x[1][i] == 2999:
-			data_test[x[0][i],x[1][i]] = data_test[x[0][i],x[1][i]-1]
+		x = np.where(np.abs(data_test) > 3.5)
+
+		for i in range(x[0].shape[0]):
+				if x[1][i] == 0:
+					data_test[x[0][i],x[1][i]] = data_test[x[0][i],x[1][i]+1]
+				elif x[1][i] == 2999:
+					data_test[x[0][i],x[1][i]] = data_test[x[0][i],x[1][i]-1]
+				else:
+					data_test[x[0][i],x[1][i]] = (data_test[x[0][i],x[1][i]-1] + data_test[x[0][i],x[1][i]+1])/2
+
+		data_test = torch.tensor(data_test).float()
+		if pos is True:
+			torch.save(torch.tensor(data_test).float(), outpath + '/pos_' + str(xi) + '.pt')
 		else:
-			data_test[x[0][i],x[1][i]] = (data_test[x[0][i],x[1][i]-1] + data_test[x[0][i],x[1][i]+1])/2
+			torch.save(torch.tensor(data_test).float(), outpath + '/neg_' + str(xi) + '.pt')
 
-	data_test = torch.tensor(data_test).float()
-	if pos is True:
-		torch.save(torch.tensor(data_test).float(), outpath + '/pos_' + str(xi) + '.pt')
-	else:
-		torch.save(torch.tensor(data_test).float(), outpath + '/neg_' + str(xi) + '.pt')
+
+def array_split_to_3(arr,s1,s2):
+	s1 = float(s1)
+	s2 = float(s2)
+	id1 = int(s1*len(arr))
+	id2 = math.floor(s1*len(arr) + s2*len(arr))
+	arr1 = arr[0:id1]
+	arr2 = arr[id1:id2]
+	arr3 = arr[id2:]
+	return arr1, arr2, arr3
 
 @click.command()
 @click.option('--gtPos', '-gp', help='Ground truth list of positive read IDs')
 @click.option('--gtNeg', '-gn', help='Ground trueh list of negative read IDs')
 @click.option('--inpath', '-i', help='The input fast5 directory path')
 @click.option('--outpath', '-o', help='The output pytorch tensor directory path')
+@click.option('--trpartition', '-trp', type=float, help='Partiton size for train set')
 @click.option('--batch', '-b', default=10000, help='Batch size, default 10000')
 @click.option('--cutoff', '-c', default=1500, help='Cutoff the first c signals')
 
-def main(gtpos, gtneg, inpath, outpath, batch, cutoff):
-	### read in pos and neg ground truth variables
-	my_file_pos = open(gtpos, "r")
-	posli = my_file_pos.readlines()
-	my_file_pos.close()
-	posli = [pi.split('\n')[0] for pi in posli]
+def main(gtpos, gtneg, inpath, outpath, trpartition, batch, cutoff):
+		### read in pos and neg ground truth variables
+		my_file_pos = open(gtpos, "r")
+		posli = my_file_pos.readlines()
+		my_file_pos.close()
+		posli = [pi.split('\n')[0] for pi in posli]
 
-	my_file_neg = open(gtneg, "r")
-	negli = my_file_neg.readlines()
-	my_file_neg.close()
-	negli = [pi.split('\n')[0] for pi in negli]
+		my_file_neg = open(gtneg, "r")
+		negli = my_file_neg.readlines()
+		my_file_neg.close()
+		negli = [pi.split('\n')[0] for pi in negli]
 
-	### make output folder
-	if not os.path.exists(outpath):
-		os.makedirs(outpath)
+		### make output folder
+		if not os.path.exists(outpath):
+				os.makedirs(outpath)
 
 
-	print("##### posli and negli length")
-	print(len(posli))
-	print(len(negli))
-	print()
+		print("##### posli and negli length")
+		print(len(posli))
+		print(len(negli))
+		print()
 
-	### split fast5 files
-	arrneg = []
-	arrpos = []
-	pi = 0
-	ni = 0
-	
-	for fileNM in glob.glob(inpath + '/*.fast5'):
-		with get_fast5_file(fileNM, mode="r") as f5:
-			print("##### file: " + fileNM)
-			for read in f5.get_reads():
-				raw_data = read.get_raw_data(scale=True)
+		### split fast5 files
+		arrneg = []
+		arrpos = []
+		pi = 0
+		ni = 0
+		pi_skip = 0
+		ni_skip = 0
 
-				### only parse reads that are long enough
-				if len(raw_data) >= (cutoff + 3000):
+		file_count = 0
+		pos_train_size = 0
+		pos_validation_size = 0
+		pos_test_size = 0
+		neg_train_size = 0
+		neg_validation_size = 0
+		neg_test_size = 0
+
+		for fileNM in glob.glob(inpath + '/*.fast5'):
+			file_count += 1
+			with get_fast5_file(fileNM, mode="r") as f5:
+				# print("##### file: " + fileNM)
+				print("processing... " + fileNM + ' ' + str(file_count) + "/" + str(len(posli)+len(negli)))
+				for read in f5.get_reads():
+					raw_data = read.get_raw_data(scale=True)
+
+				if batch and trpartition:
+					batch = None
+				elif batch:
+					### only parse reads that are long enough
+					if len(raw_data) >= (cutoff + 3000):
+						if read.read_id in posli:
+							pi += 1
+							arrpos.append(raw_data[cutoff:(cutoff + 3000)])
+							if (pi%batch == 0) and (pi != 0):
+								normalization(arrpos, pi, outpath, pos = True)
+								del arrpos
+								arrpos = []
+
+						if read.read_id in negli:
+							ni += 1
+							arrneg.append(raw_data[cutoff:(cutoff + 3000)])
+							if (ni%batch == 0) and (ni != 0):
+								normalization(arrneg, ni, outpath, pos = False)
+								del arrneg
+								arrneg = []
+					else:
+						if read.read_id in posli:
+							pi_skip += 1
+						if read.read_id in negli:
+							ni_skip += 1
+				elif trpartition:
+					s1 = float(trpartition)
+
+					pos_idx = int(s1*len(posli))
+					neg_idx = int(s1*len(negli))
+
+
 					if read.read_id in posli:
-						pi += 1
-						arrpos.append(raw_data[cutoff:(cutoff + 3000)])
-						if (pi%batch == 0) and (pi != 0):
-							normalization(arrpos, pi, outpath, pos = True)
+						### only parse reads that are long enough
+						if len(raw_data) >= (cutoff + 3000):
+							pi += 1
+							arrpos.append(raw_data[cutoff:(cutoff + 3000)])
+						else:
+							pi_skip += 1
+
+						if (pi == pos_idx):
+							pos_train_size = len(arrpos)
+							normalization(arrpos, 'train_' + str(pi), outpath, pos = True)
+							print("positive train set created")
+							del arrpos
+							arrpos = []
+
+						if (pi + pi_skip == len(posli)-1):
+							pos_validation_size = len(arrpos)
+							normalization(arrpos, 'validation_' + str(pi), outpath, pos = True)
+							print("positive validation set created")
 							del arrpos
 							arrpos = []
 
 					if read.read_id in negli:
-						ni += 1
-						arrneg.append(raw_data[cutoff:(cutoff + 3000)])
-						if (ni%batch == 0) and (ni != 0):
-							normalization(arrneg, ni, outpath, pos = False)
+						### only parse reads that are long enough
+						if len(raw_data) >= (cutoff + 3000):
+							ni += 1
+							arrneg.append(raw_data[cutoff:(cutoff + 3000)])
+						else:
+							ni_skip += 1
+
+						if (ni == neg_idx):
+							neg_train_size = len(arrneg)
+							normalization(arrneg, 'train_' + str(ni), outpath, pos = False)
+							print("negative train set created")
 							del arrneg
 							arrneg = []
 
+						if (ni + ni_skip == len(negli)-1):
+							neg_validation_size = len(arrneg)
+							normalization(arrneg, 'validation_' + str(ni), outpath, pos = False)
+							print("negative validation set created")
+							del arrneg
+							arrneg = []
+				else:
+					print("Neither batch size nor partition size is passed")
+
+		if trpartition:
+			print("pos. train partition size: ", pos_train_size)
+			print("pos. validation partition size: ", pos_validation_size)
+			print("neg. train partition size: ", neg_train_size)
+			print("neg. validation partition size: ", neg_validation_size)
+
+		print("no. of pos. reads processed: ", pi)
+		print("no. of pos. reads skipped: ", pi_skip)
+		print("no. of neg. reads processed: ", ni)
+		print("no. of neg. reads skipped: ", ni_skip)
+		print("no. of total reads processed: ", pi+ni)
+		print("no. of total reads skipped: ", pi_skip+ni_skip)
+		
 
 if __name__ == '__main__':
-	main()
+		main()


### PR DESCRIPTION
**Commit 1**
------
type: bug fix

In inference.py, the number of signals per read is cut-off by a certain value in input arguments. Therefore, when the cut-off value is larger than the read length, the read after cut-off may be empty. The problem is that has to be checked before the read is normalized. If an empty array is sent to the normalization method, the program will throw an error and possibly crash.

`if len(data_test) > 0 and it == batch:`
			`print("[Step 1]$$$$$$$$$$ Done loading data with batch " + str(batchi)+ \", Getting " + str(len(data_test)) + " of sequences")`
			`data_test = normalization(data_test, batchi)`

**Commit 2**
------

type: suggestion

issue: #2

Preprocessing.py added with a new argument to create train & validation sets with percentage values for the cases of imbalanced datasets.

eg: 
pos. reads = 150000
neg. reads = 100000

trp = 0.7 means,

pos. train partition = 70% of pos. fast5s
neg. train partition = 70% of neg. fast5s
pos. validation partition = 30% of pos. fast5s
neg. validation partition = 30% of neg. fast5s

so,

pos. train includes = 105000
neg. train includes =  70000
pos. validation includes = 45000
neg. validation includes = 30000