### PR TITLE
Add support for SLOW5 format

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Options:
   -o, --outfile PATH    The output result folder path
   -b, --batch INTEGER   Batch size
   -c, --cutoff INTEGER  Cutoff the first c signals
+  -ft, --format STRING  Raw file format (fast5, slow5)  
   --help                Show this message and exit.
 ```
 
@@ -52,6 +53,7 @@ Options:
   -o, --outpath TEXT    The output pytorch tensor directory path
   -b, --batch INTEGER   Batch size, default 10000
   -c, --cutoff INTEGER  Cutoff the first c signals
+  -ft, --format STRING  Raw file format (fast5, slow5)
   --help                Show this message and exit.
 ```
 


### PR DESCRIPTION
The implementation adds supportability for signal data with the SLOW5 format. SLOW5 is a new file format for storing signal data from Oxford Nanopore Technologies (ONT) devices. SLOW5 was developed to overcome inherent limitations in the standard FAST5 signal data format that prevent efficient, scalable analysis and cause many headaches for developers. More information can be found in the following links.

Related Publication: https://www.nature.com/articles/s41587-021-01147-4
SLOW5 Docs: https://hasindu2008.github.io/slow5tools